### PR TITLE
Add max per tx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
+# POA bridge smart contracts
+The goal of these contracts is to allow users to tokenize native POA coin into ERC20 token on ethereum mainnet.
+Home Bridge is a smart contract that should be deployed in POA.network
+Foreign Bridge is a smart contract that should be deployed in Ethereum Mainnet
+
+Responsibilities and roles of the bridge:
+- Administrator Role(representation of a multisig contract):
+  - add/remove validators
+  - set daily limits on both bridges
+  - set maximum per transaction limit on both bridges
+  - upgrade contracts in case of vulnerability
+  - set minimum required signatures from validators in order to relay a user's transaction
+- Validator Role :
+  - provide 100% uptime to relay transactions
+  - listen for Deposit events on Home bridge to mint erc20 token on Foreign bridge
+  - listen for Withdraw events on Foreign bridge to unlock funds on Home Bridge
+- User role:
+  - sends POA coins to Home bridge in order to receive ERC20 token on Foreign Bridge
+  - sends ERC20 POA20 token on Foreign Bridge in order to receive POA coins on Home Bridge
+
+
 # Dependencies
 ```bash
 npm install
@@ -28,9 +49,10 @@ that will be used as Home Bridge Proxy contract.  Example address: `0x04`
 7. Call `upgradeTo` of EternalStorageProxy that is used as  Home Bridge Proxy(step#6) with 2 parameters:
 - 0 - version of implementation contract
 - address of implementation which is the address of step#5 HomeBridge deployed contract. (`0x03`)
-8. Call `initialize` method at Home Bridge Proxy address with 2 parameters:
+8. Call `initialize` method at Home Bridge Proxy address with 3 parameters:
 - address of Home Bridge **Validators** address Proxy ( step# 1) `0x01`
 - Daily Limit in wei: Example `1000000000000000000` == 1 ether
+- Maximum Per Transaction Limit in wei: Example `100000000000000000` == 0.1 ether. Should be less than Daily Limit
 
 =====
 ## Foreign Deployment on Kovan
@@ -52,10 +74,11 @@ that will be used as Foreign Bridge Proxy contract. Example `0x08`
 16. Call `upgradeTo` of EternalStorageProxy(`0x08`) that is used as  Foreign Bridge Proxy(step#14) with 2 parameters:
 - 0 - version of implementation contract
 - address of implementation which is the address of step#15 Foreign Bridge deployed contract. (`0x09`)
-17. Call `initialize` method at Foreign Bridge Proxy(`0x08`) address with 2 parameters:
+17. Call `initialize` method at Foreign Bridge Proxy(`0x08`) address with 4 parameters:
 - address of Foreign Bridge **Validators** address Proxy ( step# 10) `0x06`
 - address of POA20 token contract. Step#9 `0x05`
 - Daily Limit in wei: Example `1000000000000000000` == 1 ether
+- Maximum Per Transaction Limit in wei: Example `100000000000000000` == 0.1 ether. Should be less than Daily Limit
 18. Call `transferOwnership` of POA20 contract(0x05) with 1 parameter:
 - address of Foreign Bridge Proxy (`0x08`) from step#14
 

--- a/contracts/upgradeable_contracts/U_ForeignBridge.sol
+++ b/contracts/upgradeable_contracts/U_ForeignBridge.sol
@@ -29,15 +29,18 @@ contract ForeignBridge is ERC677Receiver, Validatable {
     function initialize(
         address _validatorContract,
         address _erc677token,
-        uint256 _foreignDailyLimit
+        uint256 _foreignDailyLimit,
+        uint256 _maxPerTx
     ) public {
         require(!isInitialized());
         require(_validatorContract != address(0));
         require(_foreignDailyLimit > 0);
+        require(_maxPerTx > 0);
         addressStorage[keccak256("validatorContract")] = _validatorContract;
         setErc677token(_erc677token);
         setForeignDailyLimit(_foreignDailyLimit);
         uintStorage[keccak256("deployedAtBlock")] = block.number;
+        setMaxPerTx(_maxPerTx);
         setInitialize(true);
     }
 
@@ -49,6 +52,15 @@ contract ForeignBridge is ERC677Receiver, Validatable {
         erc677token().burn(_value);
         Withdraw(_from, _value, homeGasPrice());
         return true;
+    }
+
+    function setMaxPerTx(uint256 _maxPerTx) public onlyOwner {
+        require(_maxPerTx < foreignDailyLimit());
+        uintStorage[keccak256("maxPerTx")] = _maxPerTx;
+    }
+
+    function maxPerTx() public view returns(uint256) {
+        return uintStorage[keccak256("maxPerTx")];
     }
 
     function totalSpentPerDay(uint256 _day) public view returns(uint256) {
@@ -166,7 +178,7 @@ contract ForeignBridge is ERC677Receiver, Validatable {
 
     function withinLimit(uint256 _amount) public view returns(bool) {
         uint256 nextLimit = totalSpentPerDay(getCurrentDay()).add(_amount);
-        return foreignDailyLimit() >= nextLimit;
+        return foreignDailyLimit() >= nextLimit && _amount <= maxPerTx();
     }
 
     function isInitialized() public view returns(bool) {

--- a/contracts/upgradeable_contracts/U_ForeignBridge.sol
+++ b/contracts/upgradeable_contracts/U_ForeignBridge.sol
@@ -121,7 +121,7 @@ contract ForeignBridge is ERC677Receiver, Validatable {
         bytes32 hash = keccak256(message);
         bytes32 hashSender = keccak256(msg.sender, hash);
 
-        uint signed = numMessagesSigned(hashSender) + 1;
+        uint signed = numMessagesSigned(hash) + 1;
 
         if (signed > 1) {
             // Duplicated signatures
@@ -136,7 +136,7 @@ contract ForeignBridge is ERC677Receiver, Validatable {
         bytes32 signIdx = keccak256(hash, (signed-1));
         setSignatures(signIdx, signature);
 
-        setNumMessagesSigned(hashSender, signed);
+        setNumMessagesSigned(hash, signed);
 
         SignedForWithdraw(msg.sender, hash);
         if (signed == validatorContract().requiredSignatures()) {

--- a/flats/ForeignBridge_flat.sol
+++ b/flats/ForeignBridge_flat.sol
@@ -454,7 +454,7 @@ contract ForeignBridge is ERC677Receiver, Validatable {
         bytes32 hash = keccak256(message);
         bytes32 hashSender = keccak256(msg.sender, hash);
 
-        uint signed = numMessagesSigned(hashSender) + 1;
+        uint signed = numMessagesSigned(hash) + 1;
 
         if (signed > 1) {
             // Duplicated signatures
@@ -469,7 +469,7 @@ contract ForeignBridge is ERC677Receiver, Validatable {
         bytes32 signIdx = keccak256(hash, (signed-1));
         setSignatures(signIdx, signature);
 
-        setNumMessagesSigned(hashSender, signed);
+        setNumMessagesSigned(hash, signed);
 
         SignedForWithdraw(msg.sender, hash);
         if (signed == validatorContract().requiredSignatures()) {

--- a/flats/HomeBridge_flat.sol
+++ b/flats/HomeBridge_flat.sol
@@ -295,14 +295,17 @@ contract HomeBridge is OwnedUpgradeabilityStorage, Validatable {
 
     function initialize (
         address _validatorContract,
-        uint256 _homeDailyLimit
+        uint256 _homeDailyLimit,
+        uint256 _maxPerTx
     ) public {
         require(!isInitialized());
         require(_validatorContract != address(0));
         require(_homeDailyLimit > 0);
+        require(_maxPerTx > 0);
         addressStorage[keccak256("validatorContract")] = _validatorContract;
         uintStorage[keccak256("deployedAtBlock")] = block.number;
         setHomeDailyLimit(_homeDailyLimit);
+        setMaxPerTx(_maxPerTx);
         setInitialize(true);
     }
 
@@ -360,13 +363,22 @@ contract HomeBridge is OwnedUpgradeabilityStorage, Validatable {
         DailyLimit(_homeDailyLimit);
     }
 
+    function setMaxPerTx(uint256 _maxPerTx) public onlyOwner {
+        require(_maxPerTx < homeDailyLimit());
+        uintStorage[keccak256("maxPerTx")] = _maxPerTx;
+    }
+
     function getCurrentDay() public view returns(uint256) {
         return now / 1 days;
     }
 
+    function maxPerTx() public view returns(uint256) {
+        return uintStorage[keccak256("maxPerTx")];
+    }
+
     function withinLimit(uint256 _amount) public view returns(bool) {
         uint256 nextLimit = totalSpentPerDay(getCurrentDay()).add(_amount);
-        return homeDailyLimit() >= nextLimit;
+        return homeDailyLimit() >= nextLimit && _amount <= maxPerTx();
     }
 
     function isInitialized() public view returns(bool) {

--- a/migrations/3_upgradeable_deployment.js
+++ b/migrations/3_upgradeable_deployment.js
@@ -11,6 +11,7 @@ module.exports = async function(deployer, network, accounts) {
     const PROXY_OWNER = process.env.PROXY_OWNER || accounts[0];
     const homeDailyLimit = process.env.HOME_LIMIT || '1000000000000000000' // 1 ether
     const foreignDailyLimit = process.env.FOREIGN_LIMIT || '1000000000000000000' // 1 ether
+    const MAX_AMOUNT_PER_TX = process.env.MAX_AMOUNT_PER_TX || '100000000000000000' // 0.1 ether
 
     console.log('storage for home validators')
     await deployer.deploy(EternalStorageProxy, {from: PROXY_OWNER});
@@ -45,7 +46,7 @@ module.exports = async function(deployer, network, accounts) {
     const homeBridgeImplementation = await HomeBridge.deployed();
     var homeBridgeWeb3 = web3.eth.contract(HomeBridge.abi);
     var homeBridgeWeb3Instance = homeBridgeWeb3.at(homeBridgeImplementation.address);
-    var initializeDataHome = homeBridgeWeb3Instance.initialize.getData(storageBridgeValidators.address, homeDailyLimit);
+    var initializeDataHome = homeBridgeWeb3Instance.initialize.getData(storageBridgeValidators.address, homeDailyLimit, MAX_AMOUNT_PER_TX);
     await homeBridgeUpgradeable.upgradeTo('0', homeBridgeImplementation.address, {from: PROXY_OWNER});
     await web3.eth.sendTransaction({
       from: PROXY_OWNER,

--- a/migrations/3_upgradeable_deployment.js
+++ b/migrations/3_upgradeable_deployment.js
@@ -63,7 +63,8 @@ module.exports = async function(deployer, network, accounts) {
     const foreignBridgeImplementation = await ForeignBridge.deployed();
     var foreignBridgeWeb3 = web3.eth.contract(ForeignBridge.abi);
     var foreignBridgeWeb3Instance = foreignBridgeWeb3.at(foreignBridgeImplementation.address);
-    var initializeDataForeign = foreignBridgeWeb3Instance.initialize.getData(storageBridgeValidators.address, erc677token.address, foreignDailyLimit);
+    var initializeDataForeign = foreignBridgeWeb3Instance.initialize
+      .getData(storageBridgeValidators.address, erc677token.address, foreignDailyLimit, MAX_AMOUNT_PER_TX);
     await foreignBridgeUpgradeable.upgradeTo('0', foreignBridgeImplementation.address, {from: PROXY_OWNER});
 
     await web3.eth.sendTransaction({

--- a/test/foreign_bridge_test.js
+++ b/test/foreign_bridge_test.js
@@ -4,6 +4,7 @@ const POA20 = artifacts.require("POA20.sol");
 const {ERROR_MSG, ZERO_ADDRESS} = require('./setup');
 const {createMessage, sign, signatureToVRS} = require('./helpers/helpers');
 const oneEther = web3.toBigNumber(web3.toWei(1, "ether"));
+const halfEther = web3.toBigNumber(web3.toWei(0.5, "ether"));
 
 const getEvents = function(contract, filter) {
   return new Promise((resolve, reject) => {
@@ -36,13 +37,15 @@ contract('ForeignBridge', async (accounts) => {
       ZERO_ADDRESS.should.be.equal(await foreignBridge.validatorContract())
       '0'.should.be.bignumber.equal(await foreignBridge.deployedAtBlock())
       '0'.should.be.bignumber.equal(await foreignBridge.foreignDailyLimit())
+      '0'.should.be.bignumber.equal(await foreignBridge.maxPerTx())
       false.should.be.equal(await foreignBridge.isInitialized())
-      await foreignBridge.initialize(validatorContract.address, token.address, oneEther);
+      await foreignBridge.initialize(validatorContract.address, token.address, oneEther, halfEther);
 
       true.should.be.equal(await foreignBridge.isInitialized())
       validatorContract.address.should.be.equal(await foreignBridge.validatorContract());
       (await foreignBridge.deployedAtBlock()).should.be.bignumber.above(0);
       oneEther.should.be.bignumber.equal(await foreignBridge.foreignDailyLimit())
+      halfEther.should.be.bignumber.equal(await foreignBridge.maxPerTx())
     })
   })
 
@@ -51,7 +54,7 @@ contract('ForeignBridge', async (accounts) => {
     beforeEach(async () => {
       token = await POA20.new("POA ERC20 Foundation", "POA20", 18);
       foreignBridge = await ForeignBridge.new();
-      await foreignBridge.initialize(validatorContract.address, token.address, oneEther);
+      await foreignBridge.initialize(validatorContract.address, token.address, oneEther, halfEther);
       await token.transferOwnership(foreignBridge.address)
     })
     it('should allow validator to deposit', async () => {
@@ -80,7 +83,7 @@ contract('ForeignBridge', async (accounts) => {
       await validatorContractWith2Signatures.initialize(2, authoritiesTwoAccs, ownerOfValidators)
       let tokenPOA20 = await POA20.new("POA ERC20 Foundation", "POA20", 18);
       let foreignBridgeWithTwoSigs = await ForeignBridge.new();
-      await foreignBridgeWithTwoSigs.initialize(validatorContractWith2Signatures.address, tokenPOA20.address, oneEther);
+      await foreignBridgeWithTwoSigs.initialize(validatorContractWith2Signatures.address, tokenPOA20.address, oneEther, halfEther);
       await tokenPOA20.transferOwnership(foreignBridgeWithTwoSigs.address)
 
       const recipient = accounts[5];
@@ -129,35 +132,55 @@ contract('ForeignBridge', async (accounts) => {
       const user = accounts[4]
       token = await POA20.new("POA ERC20 Foundation", "POA20", 18, {from: owner});
       foreignBridge = await ForeignBridge.new();
-      await foreignBridge.initialize(validatorContract.address, token.address, oneEther);
-      await token.mint(user, oneEther, {from: owner }).should.be.fulfilled;
+      await foreignBridge.initialize(validatorContract.address, token.address, oneEther, halfEther);
+      await token.mint(user, halfEther, {from: owner }).should.be.fulfilled;
       await token.transferOwnership(foreignBridge.address, {from: owner});
-      await foreignBridge.onTokenTransfer(user, oneEther, '0x00', {from: owner}).should.be.rejectedWith(ERROR_MSG);
-      await token.transferAndCall(foreignBridge.address, oneEther, '0x00', {from: user}).should.be.fulfilled;
+      await foreignBridge.onTokenTransfer(user, halfEther, '0x00', {from: owner}).should.be.rejectedWith(ERROR_MSG);
+      await token.transferAndCall(foreignBridge.address, halfEther, '0x00', {from: user}).should.be.fulfilled;
       '0'.should.be.bignumber.equal(await token.totalSupply());
       '0'.should.be.bignumber.equal(await token.balanceOf(user));
     })
     it('should not allow to burn more than the limit', async () => {
       const owner = accounts[3]
       const user = accounts[4]
-      const valueMoreThanLimit = oneEther.add(1);
+      const valueMoreThanLimit = halfEther.add(1);
       token = await POA20.new("POA ERC20 Foundation", "POA20", 18, {from: owner});
       foreignBridge = await ForeignBridge.new();
-      await foreignBridge.initialize(validatorContract.address, token.address, oneEther);
+      await foreignBridge.initialize(validatorContract.address, token.address, oneEther, halfEther);
       await token.mint(user, valueMoreThanLimit, {from: owner }).should.be.fulfilled;
       await token.transferOwnership(foreignBridge.address, {from: owner});
       await token.transferAndCall(foreignBridge.address, valueMoreThanLimit, '0x00', {from: user}).should.be.rejectedWith(ERROR_MSG);
       valueMoreThanLimit.should.be.bignumber.equal(await token.totalSupply());
       valueMoreThanLimit.should.be.bignumber.equal(await token.balanceOf(user));
-      const {logs} = await token.transferAndCall(foreignBridge.address, oneEther, '0x00', {from: user}).should.be.fulfilled;
+      const {logs} = await token.transferAndCall(foreignBridge.address, halfEther, '0x00', {from: user}).should.be.fulfilled;
       '1'.should.be.bignumber.equal(await token.totalSupply());
       '1'.should.be.bignumber.equal(await token.balanceOf(user));
       const events = await getEvents(foreignBridge, {event: 'Withdraw'});
       events[0].args.should.be.deep.equal({
         recipient: user,
-        value: oneEther,
+        value: halfEther,
         homeGasPrice: web3.toBigNumber(web3.toWei(1, "gwei"))
       })
+    })
+    it('should only let to send within maxPerTx limit', async () => {
+      const owner = accounts[3]
+      const user = accounts[4]
+      const valueMoreThanLimit = halfEther.add(1);
+      token = await POA20.new("POA ERC20 Foundation", "POA20", 18, {from: owner});
+      foreignBridge = await ForeignBridge.new();
+      await foreignBridge.initialize(validatorContract.address, token.address, oneEther, halfEther);
+      await token.mint(user, oneEther.add(1), {from: owner }).should.be.fulfilled;
+      await token.transferOwnership(foreignBridge.address, {from: owner});
+      await token.transferAndCall(foreignBridge.address, valueMoreThanLimit, '0x00', {from: user}).should.be.rejectedWith(ERROR_MSG);
+      oneEther.add(1).should.be.bignumber.equal(await token.totalSupply());
+      oneEther.add(1).should.be.bignumber.equal(await token.balanceOf(user));
+      await token.transferAndCall(foreignBridge.address, halfEther, '0x00', {from: user}).should.be.fulfilled;
+      valueMoreThanLimit.should.be.bignumber.equal(await token.totalSupply());
+      valueMoreThanLimit.should.be.bignumber.equal(await token.balanceOf(user));
+      await token.transferAndCall(foreignBridge.address, halfEther, '0x00', {from: user}).should.be.fulfilled;
+      '1'.should.be.bignumber.equal(await token.totalSupply());
+      '1'.should.be.bignumber.equal(await token.balanceOf(user));
+      await token.transferAndCall(foreignBridge.address, '1', '0x00', {from: user}).should.be.rejectedWith(ERROR_MSG);
     })
   })
 
@@ -170,7 +193,7 @@ contract('ForeignBridge', async (accounts) => {
       await validatorContractWith2Signatures.initialize(2, authoritiesTwoAccs, ownerOfValidators)
       tokenPOA20 = await POA20.new("POA ERC20 Foundation", "POA20", 18);
       foreignBridgeWithTwoSigs = await ForeignBridge.new();
-      await foreignBridgeWithTwoSigs.initialize(validatorContractWith2Signatures.address, tokenPOA20.address, oneEther);
+      await foreignBridgeWithTwoSigs.initialize(validatorContractWith2Signatures.address, tokenPOA20.address, oneEther, halfEther);
       await tokenPOA20.transferOwnership(foreignBridgeWithTwoSigs.address)
 
     })


### PR DESCRIPTION
Problem: Bridge should be able to limit amount of funds to be sent in 1 transaction
Solution: Provide maxPerTx method that also includes into `withinLimit` function